### PR TITLE
feat: Add better support for custom elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ JSX renderer for the [Contentful Rich Text](https://www.contentful.com/developer
 
 </div>
 
-> ⚠️ **I no longer actively maintain this package.** I decided to team up with [@mgmolisani](https://github.com/mgmolisani) to contribute an [official `rich-text-react-renderer` package](https://github.com/contentful/rich-text/pull/71) with a [more flexible API](https://github.com/contentful/rich-text/pull/65#issuecomment-456171388).
-
 <!-- TOC -->
 
 - [Installation](#installation)

--- a/README.md
+++ b/README.md
@@ -129,19 +129,25 @@ If you only wish to provide a component override, a simplified syntax is availab
 const overrides = {
   [BLOCKS.PARAGRAPH]: MyParagraph
 };
+
+// or
+
+const overrides = {
+  p: MyParagraph
+};
 ```
 
 Any conflicts between passed `props` and the specific properties above will be resolved in favor of `@madebyconnor/rich-text-to-jsx`'s code. `classNames` are merged automatically. The `uri` prop on `INLINES.HYPERLINK` nodes is renamed to `href` for convenience.
 
-For **custom elements** (entries and assets), you need to specify the component for each possible node type. This enables you to use different components for the same entry, depending on whether it is rendered inline, as a block or as a hyperlink.
+For **custom elements** (entries and assets), you need to specify the component for each possible node type and content type (entries) or [mime type group](https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters/filtering-assets-by-mime-type) (assets). This enables you to use different components for the same entry, depending on whether it is rendered inline, as a block or as a hyperlink.
 
 Custom elements receive the data in `node.data.target` as props.
 
-For example, let's say you have an entry of the content type `page`. When the `page` entry is referenced as a hyperlink, an anchor should be rendered. When the `page` entry is embedded as a block, a preview with its title and subtitle should be rendered. Here's how you could achieve that:
+Let's say you have an entry of the content type `page`. When the `page` entry is referenced as a hyperlink, an anchor should be rendered. When the `page` entry is embedded as a block, a preview with its title and subtitle should be rendered. Here's how you could achieve that:
 
 ```jsx
 const PageLink = ({ slug, children }) => <a href={slug}>{children}</a>;
-const PageEmbed = ({ title, summary, className }) => (
+const PagePreview = ({ title, summary, className }) => (
   <div className={className}>
     <h2>{title}</h2>
     <p>{summary}</p>
@@ -149,12 +155,41 @@ const PageEmbed = ({ title, summary, className }) => (
 );
 
 const overrides = {
-  page: {
-    [INLINES.ENTRY_HYPERLINK]: PageLink,
-    [BLOCKS.EMBEDDED_ENTRY]: {
-      component: PageEmbed,
+  [INLINES.ENTRY_HYPERLINK]: {
+    page: PageLink
+  },
+  [BLOCKS.EMBEDDED_ENTRY]: {
+    page: {
+      component: PagePreview,
       props: {
-        className: 'page-embed'
+        className: 'page-preview'
+      }
+    }
+  }
+};
+```
+
+And here's a similar example with an asset:
+
+```jsx
+const ImageLink = ({ file, title }) => (
+  <a href={file.url} download>
+    {title}
+  </a>
+);
+const Image = ({ file, title, className }) => (
+  <img className={className} src={file.url} alt={title} />
+);
+
+const overrides = {
+  [INLINES.ENTRY_HYPERLINK]: {
+    image: ImageLink
+  },
+  [BLOCKS.EMBEDDED_ENTRY]: {
+    image: {
+      component: Image,
+      props: {
+        className: 'image--fullwidth'
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@madebyconnor/rich-text-to-jsx",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "JSX renderer for the Contentful rich text field type.",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/src/__snapshots__/rich-text-to-jsx.spec.js.snap
+++ b/src/__snapshots__/rich-text-to-jsx.spec.js.snap
@@ -1,5 +1,51 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Rich text to JSX customNodeToJsx should render an asset hyperlink 1`] = `
+<Override
+  file={
+    Object {
+      "contentType": "image/jpg",
+      "details": Object {
+        "image": Object {
+          "height": 500,
+          "width": 800,
+        },
+        "size": 240963,
+      },
+      "fileName": "random-unsplash.jpg",
+      "url": "https://source.unsplash.com/random/800x500",
+    }
+  }
+  id="4fgGUXCJXWOQUAEQqCS8MW"
+  title="Random photo from Unsplash.com"
+  updatedAt="2019-01-14T04:57:27.049Z"
+>
+  ham hock
+</Override>
+`;
+
+exports[`Rich text to JSX customNodeToJsx should render an embedded asset 1`] = `
+<Override
+  file={
+    Object {
+      "contentType": "image/jpg",
+      "details": Object {
+        "image": Object {
+          "height": 500,
+          "width": 800,
+        },
+        "size": 240963,
+      },
+      "fileName": "random-unsplash.jpg",
+      "url": "https://source.unsplash.com/random/800x500",
+    }
+  }
+  id="4fgGUXCJXWOQUAEQqCS8MW"
+  title="Random photo from Unsplash.com"
+  updatedAt="2019-01-14T04:57:27.049Z"
+/>
+`;
+
 exports[`Rich text to JSX customNodeToJsx should render an embedded entry block 1`] = `
 <Override
   contentType="page"

--- a/src/rich-text-to-jsx.js
+++ b/src/rich-text-to-jsx.js
@@ -110,16 +110,18 @@ export function customNodeToJsx(node, options, key) {
   const { data, content, nodeType } = node;
   const { overrides, createElement } = options;
 
-  const contentType = get(data, 'target.contentType');
+  const contentType =
+    get(data, 'target.contentType') ||
+    get(data, 'target.file.contentType', '').split('/')[0];
 
   if (!contentType) {
     return unknownNodeToJsx(node, options, key);
   }
 
-  const elementOverrides = overrides[contentType];
+  const elementOverrides = overrides[nodeType];
 
   const DefaultElement = helpers.isBlock(node) ? BlockElement : InlineElement;
-  const element = getElement(nodeType, elementOverrides) || DefaultElement;
+  const element = getElement(contentType, elementOverrides) || DefaultElement;
 
   const props = getProps(nodeType, elementOverrides, {
     ...data.target,

--- a/src/rich-text-to-jsx.spec.js
+++ b/src/rich-text-to-jsx.spec.js
@@ -71,11 +71,9 @@ describe('Rich text to JSX', () => {
   });
 
   describe('customNodeToJsx', () => {
-    // FIXME: Figure out how to handle assets.
-    // They don't have a content type, only a mime-type.
-    it.skip('should render an embedded asset', () => {
+    it('should render an embedded asset', () => {
       const overrides = {
-        'image/jpg': { [BLOCKS.EMBEDDED_ASSET]: Override }
+        [BLOCKS.EMBEDDED_ASSET]: { image: Override }
       };
       const actual = RichTextService.customNodeToJsx(embeddedAsset, {
         ...options,
@@ -83,12 +81,9 @@ describe('Rich text to JSX', () => {
       });
       expect(actual).toMatchSnapshot();
     });
-
-    // FIXME: Figure out how to handle assets.
-    // They don't have a content type, only a mime-type.
-    it.skip('should render an asset hyperlink', () => {
+    it('should render an asset hyperlink', () => {
       const overrides = {
-        route: { [INLINES.ASSET_HYPERLINK]: Override }
+        [INLINES.ASSET_HYPERLINK]: { image: Override }
       };
       const actual = RichTextService.customNodeToJsx(assetHyperlink, {
         ...options,
@@ -99,7 +94,7 @@ describe('Rich text to JSX', () => {
 
     it('should render an embedded entry block', () => {
       const overrides = {
-        page: { [BLOCKS.EMBEDDED_ENTRY]: Override }
+        [BLOCKS.EMBEDDED_ENTRY]: { page: Override }
       };
       const actual = RichTextService.customNodeToJsx(embeddedEntryBlock, {
         ...options,
@@ -110,7 +105,7 @@ describe('Rich text to JSX', () => {
 
     it('should render an embedded entry inline', () => {
       const overrides = {
-        page: { [INLINES.EMBEDDED_ENTRY]: Override }
+        [INLINES.EMBEDDED_ENTRY]: { page: Override }
       };
       const actual = RichTextService.customNodeToJsx(embeddedEntryInline, {
         ...options,
@@ -121,7 +116,7 @@ describe('Rich text to JSX', () => {
 
     it('should render an entry hyperlink', () => {
       const overrides = {
-        route: { [INLINES.ENTRY_HYPERLINK]: Override }
+        [INLINES.ENTRY_HYPERLINK]: { route: Override }
       };
       const actual = RichTextService.customNodeToJsx(entryHyperlink, {
         ...options,


### PR DESCRIPTION
## Changes

- **[BREAKING CHANGE]** Invert custom element override hierarchy: Overrides for custom elements are now indexed the other way round: `nodeType -> contentType/mimeType` instead of `contentType/mimeType -> nodeType`

Resolves #1.