### PR TITLE
Handle content type after an import with gatsby-source-contentful

### DIFF
--- a/src/rich-text-to-jsx.js
+++ b/src/rich-text-to-jsx.js
@@ -139,7 +139,10 @@ export function entryNodeToJsx(node, options, key) {
   const { data, content, nodeType } = node;
   const { overrides, createElement } = options;
 
-  const contentType = get(data, 'target.contentType');
+  let contentType = get(data, 'target.contentType');
+  if(!contentType) {
+    contentType = get(data, 'target.sys.contentType.sys.id');
+  }
 
   if (!contentType) {
     return unknownNodeToJsx(node, options, key);


### PR DESCRIPTION
[Gatsby source contentful](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful) imports Rich Text then resolves all the child nodes, which means embedded entries look like the following node. This PR just checks that the content type of a target embedded entry isn't also located in `target.sys.contentType.sys.id`.

```json
{
      "data": {
        "target": {
          "sys": {
            ...
            "contentType": {
              "sys": {
                "type": "Link",
                "linkType": "ContentType",
                "id": "contentInlineImage"
              }
            }
          },
          "fields": {
            ...
          }
        }
      },
      "content": [],
      "nodeType": "embedded-entry-block"
    },

````
