### PR TITLE
Add prop-types as peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "jest": "^29.5.0",
     "jest-junit": "^16.0.0",
     "jest-serializer-html": "^7.1.0",
-    "prop-types": "^15.6.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-test-renderer": "^18.2.0",
@@ -66,7 +65,8 @@
     "size-limit": "^0.21.1"
   },
   "peerDependencies": {
-    "react": ">= 16.0.0"
+    "react": ">= 16.0.0",
+    "prop-types": ">= 15"
   },
   "dependencies": {
     "@contentful/rich-text-types": "^16.0.3"

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "jest": "^29.5.0",
     "jest-junit": "^16.0.0",
     "jest-serializer-html": "^7.1.0",
+    "prop-types": "^15.6.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-test-renderer": "^18.2.0",


### PR DESCRIPTION
## Purpose

Describe the problem you are trying to solve.
`prop-types` are missing as dependency when the main application is not using them.

## Approach and changes
I checked the build from the `dist` which is kind of a good approach.
https://www.npmjs.com/package/@madebyconnor/rich-text-to-jsx?activeTab=code
But when the app is running in `development` mode. The `prop-types` still need to be available. And since the main app is not using it, there needs to be way for the package to warn or install it. 

Package managers don't still dependencies from `devDependencies` so adding `prop-types` as `peerDependency` so it can be warned to add to main app.

Here is a repo url with basic `NextJS` app that doesn't use `prop-types` out of the box 
https://stackblitz.com/edit/stackblitz-starters-onz7kr?file=pages%2Findex.js