### PR TITLE
Add default elements for table node types

### DIFF
--- a/.changeset/seven-plants-appear.md
+++ b/.changeset/seven-plants-appear.md
@@ -1,0 +1,5 @@
+---
+'@madebyconnor/rich-text-to-jsx': minor
+---
+
+Added default elements for table node types.

--- a/README.md
+++ b/README.md
@@ -42,8 +42,6 @@ Install `@madebyconnor/rich-text-to-jsx` with your favorite package manager.
 ```sh
 # npm
 npm i @madebyconnor/rich-text-to-jsx
-# yarn v1
-yarn add @madebyconnor/rich-text-to-jsx
 ```
 
 ## Getting started

--- a/src/__fixtures__/index.js
+++ b/src/__fixtures__/index.js
@@ -134,6 +134,97 @@ export const hr = {
   nodeType: BLOCKS.HR,
 };
 
+export const table = {
+  nodeType: BLOCKS.TABLE,
+  data: {},
+  content: [
+    {
+      nodeType: BLOCKS.TABLE_ROW,
+      data: {},
+      content: [
+        {
+          nodeType: BLOCKS.TABLE_HEADER_CELL,
+          data: {},
+          content: [
+            {
+              nodeType: BLOCKS.PARAGRAPH,
+              data: {},
+              content: [
+                {
+                  nodeType: 'text',
+                  data: {},
+                  marks: [],
+                  value: 'A 1',
+                },
+              ],
+            },
+          ],
+        },
+        {
+          nodeType: BLOCKS.TABLE_HEADER_CELL,
+          data: {},
+          content: [
+            {
+              nodeType: BLOCKS.PARAGRAPH,
+              data: {},
+              content: [
+                {
+                  nodeType: 'text',
+                  data: {},
+                  marks: [],
+                  value: 'B 1',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      nodeType: BLOCKS.TABLE_ROW,
+      data: {},
+      content: [
+        {
+          nodeType: BLOCKS.TABLE_CELL,
+          data: {},
+          content: [
+            {
+              nodeType: BLOCKS.PARAGRAPH,
+              data: {},
+              content: [
+                {
+                  nodeType: 'text',
+                  data: {},
+                  marks: [],
+                  value: 'A 2',
+                },
+              ],
+            },
+          ],
+        },
+        {
+          nodeType: BLOCKS.TABLE_CELL,
+          data: {},
+          content: [
+            {
+              nodeType: BLOCKS.PARAGRAPH,
+              data: {},
+              content: [
+                {
+                  nodeType: 'text',
+                  data: {},
+                  marks: [],
+                  value: 'B 2',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
 export const assetLink = {
   sys: {
     id: '9mpxT4zsRi6Iwukey8KeM',

--- a/src/__snapshots__/rich-text-to-jsx.spec.js.snap
+++ b/src/__snapshots__/rich-text-to-jsx.spec.js.snap
@@ -379,6 +379,32 @@ exports[`Rich text to JSX richTextToJsx should parse and render rich text into J
       }
     }
   />,
+  <Table>
+    <tr>
+      <th>
+        <p>
+          A 1
+        </p>
+      </th>
+      <th>
+        <p>
+          B 1
+        </p>
+      </th>
+    </tr>
+    <tr>
+      <td>
+        <p>
+          A 2
+        </p>
+      </td>
+      <td>
+        <p>
+          B 2
+        </p>
+      </td>
+    </tr>
+  </Table>,
 ]
 `;
 

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -1,0 +1,29 @@
+import React from 'react';
+
+/**
+ * Default element for tables.
+ */
+function Table({ children }) {
+  return (
+    <table>
+      <tbody>{children}</tbody>
+    </table>
+  );
+}
+
+if (process.env.NODE_ENV !== 'production') {
+  // eslint-disable-next-line global-require
+  const PropTypes = require('prop-types');
+
+  Table.propTypes = {
+    /**
+     * The table rows and cells
+     */
+    children: PropTypes.node,
+  };
+}
+
+/**
+ * @component
+ */
+export default Table;

--- a/src/components/Table/Table.spec.js
+++ b/src/components/Table/Table.spec.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { create } from 'react-test-renderer';
+
+import { table } from '../../__fixtures__';
+
+import Table from './Table';
+
+describe('Table', () => {
+  it('should render a table', () => {
+    const actual = create(<Table {...table} />);
+    expect(actual).toMatchSnapshot();
+  });
+});

--- a/src/components/Table/__snapshots__/Table.spec.js.snap
+++ b/src/components/Table/__snapshots__/Table.spec.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Table should render a table 1`] = `
+<table>
+  <tbody />
+</table>
+`;

--- a/src/components/Table/index.js
+++ b/src/components/Table/index.js
@@ -1,0 +1,3 @@
+import Table from './Table';
+
+export default Table;

--- a/src/rich-text-to-jsx.js
+++ b/src/rich-text-to-jsx.js
@@ -10,6 +10,7 @@ import BlockElement from './components/BlockElement';
 import InlineElement from './components/InlineElement';
 import AssetLink from './components/AssetLink';
 import Image from './components/Image';
+import Table from './components/Table';
 import Video from './components/Video';
 import Audio from './components/Audio';
 
@@ -37,6 +38,10 @@ const tagMap = {
   [BLOCKS.LIST_ITEM]: 'li',
   [BLOCKS.QUOTE]: 'blockquote',
   [BLOCKS.HR]: 'hr',
+  [BLOCKS.TABLE]: Table,
+  [BLOCKS.TABLE_ROW]: 'tr',
+  [BLOCKS.TABLE_HEADER_CELL]: 'th',
+  [BLOCKS.TABLE_CELL]: 'td',
   [INLINES.HYPERLINK]: 'a',
   [MARKS.BOLD]: 'strong',
   [MARKS.ITALIC]: 'em',

--- a/src/rich-text-to-jsx.spec.js
+++ b/src/rich-text-to-jsx.spec.js
@@ -10,6 +10,7 @@ import {
   boldAndItalic,
   unorderedList,
   hr,
+  table,
   embeddedImage,
   embeddedVideo,
   embeddedAudio,
@@ -29,6 +30,7 @@ describe('Rich text to JSX', () => {
         paragraph,
         embeddedEntryBlock,
         embeddedImage,
+        table,
       ]);
       const actual = richTextToJsx(richText);
       expect(actual).toMatchSnapshot();


### PR DESCRIPTION
Closes #213.

## Purpose

Contentful added support for tables to Rich Text [a while ago](https://www.contentful.com/blog/tables-rich-text-fields/). While it's already been possible to render tables using overrides, this PR adds default elements to support tables out of the box.

## Approach and changes

- Added default elements for the table node types:
  - `BLOCKS.TABLE`: `<table><tbody>...</tbody></table>`
  - `BLOCKS.TABLE_ROW`: `<tr>`
  - `BLOCKS.TABLE_HEADER_CELL`: `<th>`
  - `BLOCKS.TABLE_CELL`: `<td>`
